### PR TITLE
Monitoring client geoip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,8 +179,9 @@ dependencies = [
 
 [[package]]
 name = "bitswap-monitoring-client"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
+ "celes",
  "chrono",
  "clap",
  "failure",
@@ -190,6 +191,8 @@ dependencies = [
  "ipfs_monitoring_plugin_client",
  "lazy_static",
  "log",
+ "maxminddb",
+ "multiaddr",
  "prometheus",
  "prometheus_exporter",
  "serde",
@@ -343,6 +346,15 @@ name = "cc"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+
+[[package]]
+name = "celes"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e30b649e0a7a41e2ea1714e65e5bc5c857ddca7569752fa540ab7c582344c178"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cfg-if"
@@ -1785,6 +1797,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
+name = "ipnetwork"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4088d739b183546b239688ddbc79891831df421773df95e236daf7867866d355"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "itertools"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1886,6 +1907,18 @@ name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
+name = "maxminddb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe2ba61113f9f7a9f0e87c519682d39c43a6f3f79c2cc42c3ba3dda83b1fa334"
+dependencies = [
+ "ipnetwork",
+ "log",
+ "memchr 2.4.1",
+ "serde",
+]
 
 [[package]]
 name = "maybe-uninit"

--- a/bitswap-discovery-probe/src/main.rs
+++ b/bitswap-discovery-probe/src/main.rs
@@ -557,20 +557,11 @@ impl Probe {
 
         // Create a constant-width identifier for logging.
         // This makes logging output nicely aligned :)
-        let ident = match &event.inner {
-            EventType::BitswapMessage(msg) => {
-                let mut addrs = msg
-                    .connected_addresses
-                    .iter()
-                    .map(|ma| format!("{}", ma))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                addrs.truncate(30);
-                format!("{:52} [{:30}]", event.peer, addrs,)
-            }
-            EventType::ConnectionEvent(conn_event) => {
-                format!("{:52} {:32}", event.peer, format!("{}", conn_event.remote))
-            }
+        // We only use this for debug logging, so we only compute it if debug logging is enabled.
+        let ident = if log_enabled!(log::Level::Debug) {
+            event.constant_width_identifier()
+        } else {
+            "".to_string()
         };
 
         match event.inner {

--- a/bitswap-monitoring-client/Cargo.toml
+++ b/bitswap-monitoring-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitswap-monitoring-client"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Leo Balduf <leobalduf@gmail.com>"]
 edition = "2018"
 
@@ -20,3 +20,12 @@ lazy_static = "1.4.0"
 serde = "1.0.110"
 serde_yaml = "0.8.13"
 clap = "2.33.3"
+
+# MaxMind database reader.
+maxminddb = "0.23.0"
+
+# Multiaddress parser.
+multiaddr = "^0.13"
+
+# ISO 3166-1 countries.
+celes = "2.2.0"

--- a/bitswap-monitoring-client/README.md
+++ b/bitswap-monitoring-client/README.md
@@ -2,8 +2,9 @@
 
 This package implements a client for the IPFS Bitswap monitoring TCP server.
 It reads and processes messages from multiple monitors and outputs various metrics via prometheus.
+It also uses [MaxMind's GeoLite2 database](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data) to geolocate requests.
 
-See also [the plugin](https://github.com/scriptkitty/ipfs-metric-exporter).
+See also [the plugin](https://github.com/wiberlin/ipfs-metric-exporter).
 
 ## Configuration
 
@@ -12,13 +13,21 @@ The location of the configuration file can be specified with the `--config` para
 This is an example config file, see also the [file](./config.yaml) and the [implementation](./src/config.rs):
 
 ```yaml
-# This is a config file for the wantlist-client tool.
+# This is a config file for the bitswap-monitoring-client tool.
+
+# Address to listen and serve prometheus metrics on.
+prometheus_address: "0.0.0.0:8080"
+
+# Specifies the path to the MaxMind GeoLite databases.
+# Defaults to /usr/local/share/GeoIP if unspecified.
+#geoip_database_path: "/usr/local/share/GeoIP"
+
+# List of monitors to connect to.
 monitors:
   - name: "DE1"
     address: "10.0.1.5:4321"
   - name: "DE2"
     address: "10.0.1.2:4321"
-prometheus_address: "0.0.0.0:8080"
 ```
 
 Each monitor is configured with a name and the remote endpoint to connect to.
@@ -27,17 +36,36 @@ The `prometheus_address` specifies the local endpoint to listen and serve Promet
 ## Metrics
 
 Metrics are provided via a Prometheus HTTP endpoint.
+All metrics contain fields for the origin `monitor` (which is configured with the `name` field of the configuration file) as well as the `origin_country` of the logged event.
+Metrics for origin countries are created on the fly, if any events from that country are logged.
+There are two special countries `Unknown` and `Error`, indicating whether we were unable to determine an origin for an event, or whether GeoIP lookup failed with an error.
+See also the [implementation](./src/prom.rs).
+
+### `bitswap_messages_received`
+
+A counter that counts incoming Bitswap messages.
+The IPFS instrumentation emits JSON objects that are either a connection event or an incoming Bitswap message.
+This tracks incoming Bitswap messages, and counts whether they contain a wantlist.
+
+### `bitswap_blocks_received`
+
+A counter that counts how many blocks were received via Bitswap.
+
+### `bitswap_block_presences_received`
+
+A counter that counts how many block presence indications were received via Bitswap, by the `presence_type` (`have` or `dont_have`).
 
 ### `wantlist_messages_received`
 
-A counter that tracks the number of wantlist messages received by monitor.
-The IPFS instrumentation emits JSON objects that are either a connection event or a wantlist message -- this tracks only wantlist messages.
+A counter that tracks the number of Bitswap messages received for which the `want_list` was not empty, by whether the wantlist was `full` or incremental.
 A message may contain multiple entries.
 
 ### `wantlist_entries_received`
 
-A counter that tracks the number of wantlist entries received by monitor, message type, and `send_dont_have` flag.
+A counter that tracks the number of wantlist entries received by `entry_type`, and `send_dont_have` flag.
+Entry types are `want_block`, `want_have`, and `cancel`.
+The `send_dont_have` flag is only valid for requests (i.e., it has no meaning for `cancel` entries).
 
-### `connection_events`
+### `connection_events_(connected|disconnected)`
 
-A counter that tracks the number of connection events by monitor, event type, and whether there was a ledger entry present for the peer.
+Counters that track the number of connection or disconnection events.

--- a/bitswap-monitoring-client/config.yaml
+++ b/bitswap-monitoring-client/config.yaml
@@ -1,5 +1,13 @@
 # This is a config file for the bitswap-monitoring-client tool.
+
+# Address to listen and serve prometheus metrics on.
+prometheus_address: "0.0.0.0:8088"
+
+# Specifies the path to the MaxMind GeoLite databases.
+# Defaults to /usr/local/share/GeoIP if unspecified.
+#geoip_database_path: "/usr/local/share/GeoIP"
+
+# List of monitors to connect to.
 monitors:
   - name: "local"
     address: "127.0.0.1:8181"
-prometheus_address: "0.0.0.0:8088"

--- a/bitswap-monitoring-client/src/config.rs
+++ b/bitswap-monitoring-client/src/config.rs
@@ -6,17 +6,26 @@ use std::path::Path;
 use crate::Result;
 
 /// Configuration file for bitswap monitoring client.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct Config {
     /// Configures what monitors to connect to.
     pub(crate) monitors: Vec<MonitorConfig>,
 
     /// Specifies on what address a prometheus endpoint will be created.
     pub(crate) prometheus_address: String,
+
+    /// Specifies where MaxMind GeoLite databases are located.
+    /// Defaults to /usr/local/share/GeoIP if unspecified.
+    #[serde(default = "default_geoip_database_path")]
+    pub(crate) geoip_database_path: String,
+}
+
+fn default_geoip_database_path() -> String {
+    "/usr/local/share/GeoIP".to_string()
 }
 
 /// Configuration for a single monitor to connect to.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct MonitorConfig {
     /// The name of the monitor.
     pub(crate) name: String,

--- a/bitswap-monitoring-client/src/main.rs
+++ b/bitswap-monitoring-client/src/main.rs
@@ -197,20 +197,11 @@ async fn connect_and_receive(
 
                 // Create a constant-width identifier for logging.
                 // This makes logging output nicely aligned :)
-                let ident = match &event.inner {
-                    EventType::BitswapMessage(msg) => {
-                        let mut addrs = msg
-                            .connected_addresses
-                            .iter()
-                            .map(|ma| format!("{}", ma))
-                            .collect::<Vec<_>>()
-                            .join(", ");
-                        addrs.truncate(30);
-                        format!("{:52} [{:30}]", event.peer, addrs,)
-                    }
-                    EventType::ConnectionEvent(conn_event) => {
-                        format!("{:52} {:32}", event.peer, format!("{}", conn_event.remote))
-                    }
+                // We only use this in debug logging, so we only create it if debug logging is enabled.
+                let ident = if log_enabled!(log::Level::Debug) {
+                    event.constant_width_identifier()
+                } else {
+                    "".to_string()
                 };
 
                 match &event.inner {

--- a/bitswap-monitoring-client/src/prom.rs
+++ b/bitswap-monitoring-client/src/prom.rs
@@ -1,57 +1,197 @@
+use failure::{err_msg, ResultExt};
 use ipfs_resolver_common::Result;
+use prometheus::core::{AtomicI64, GenericCounter};
 use prometheus::IntCounterVec;
 use prometheus_exporter::PrometheusExporter;
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::thread;
 
 lazy_static! {
     pub static ref WANTLIST_ENTRIES_RECEIVED: IntCounterVec = register_int_counter_vec!(
         "wantlist_entries_received",
-        "number of wantlist entries received by monitor, entry type, and send_dont_have",
-        &["monitor", "entry_type", "send_dont_have"]
+        "number of wantlist entries received by monitor, entry type, send_dont_have, and origin country",
+        &["monitor", "entry_type", "send_dont_have","origin_country"]
     )
     .unwrap();
     pub static ref WANTLIST_MESSAGES_RECEIVED: IntCounterVec = register_int_counter_vec!(
         "wantlist_messages_received",
-        "number of wantlist messages received by monitor and whether the message was a full wantlist",
-        &["monitor","full"]
+        "number of bitswap messages received for which the wantlist was not empty, by monitor, whether the message was a full wantlist, and origin country",
+        &["monitor","full","origin_country"]
     )
     .unwrap();
 
     pub static ref CONNECTION_EVENTS_CONNECTED: IntCounterVec = register_int_counter_vec!(
         "connection_events_connected",
-        "number of connect events by monitor",
-        &["monitor"]
+        "number of connect events by monitor and origin country",
+        &["monitor","origin_country"]
     )
     .unwrap();
 
     pub static ref CONNECTION_EVENTS_DISCONNECTED: IntCounterVec = register_int_counter_vec!(
         "connection_events_disconnected",
-        "number of disconnect events by monitor",
-        &["monitor"]
+        "number of disconnect events by monitor and origin country",
+        &["monitor","origin_country"]
     )
     .unwrap();
 
     pub static ref BITSWAP_MESSAGES_RECEIVED: IntCounterVec = register_int_counter_vec!(
         "bitswap_messages_received",
-        "number of bitswap messages (both requests and responses) received by monitor",
-        &["monitor"]
+        "number of bitswap messages (both requests and responses) received by monitor and origin country",
+        &["monitor","origin_country"]
     )
     .unwrap();
 
     pub static ref BITSWAP_BLOCKS_RECEIVED: IntCounterVec = register_int_counter_vec!(
         "bitswap_blocks_received",
-        "number of blocks received via bitswap, by monitor",
-        &["monitor"]
+        "number of blocks received via bitswap, by monitor and origin country",
+        &["monitor","origin_country"]
     )
     .unwrap();
 
     pub static ref BITSWAP_BLOCK_PRESENCES_RECEIVED: IntCounterVec = register_int_counter_vec!(
         "bitswap_block_presences_received",
-        "number of block presences received via bitswap, by monitor and presence type",
-        &["monitor","presence_type"]
+        "number of block presences received via bitswap, by monitor, presence type, and origin country",
+        &["monitor","presence_type","origin_country"]
     )
     .unwrap();
+}
+
+/// Country name and code constants for various error conditions.
+/// These are used as both the two-letter country code and the full country name.
+pub(crate) static COUNTRY_NAME_UNKNOWN: &'static str = "Unknown";
+pub(crate) static COUNTRY_NAME_ERROR: &'static str = "Error";
+
+/// A set of metrics instantiated by monitor name and country.
+pub(crate) struct MetricsByMonitorAndCountry {
+    /// Counter for Bitswap messages.
+    pub(crate) num_messages: GenericCounter<AtomicI64>,
+
+    /// Counter for blocks received via Bitswap.
+    pub(crate) num_blocks: GenericCounter<AtomicI64>,
+
+    /// Counters for block presences received via Bitswap, by presence type.
+    pub(crate) num_block_presence_have: GenericCounter<AtomicI64>,
+    pub(crate) num_block_presence_dont_have: GenericCounter<AtomicI64>,
+
+    /// Counters for Bitswap messages containing a wantlist.
+    pub(crate) num_messages_with_wl_incremental: GenericCounter<AtomicI64>,
+    pub(crate) num_messages_with_wl_full: GenericCounter<AtomicI64>,
+
+    /// Counters for wantlist entries by type.
+    pub(crate) num_entries_cancel: GenericCounter<AtomicI64>,
+    pub(crate) num_entries_want_block: GenericCounter<AtomicI64>,
+    pub(crate) num_entries_want_block_send_dont_have: GenericCounter<AtomicI64>,
+    pub(crate) num_entries_want_have: GenericCounter<AtomicI64>,
+    pub(crate) num_entries_want_have_send_dont_have: GenericCounter<AtomicI64>,
+
+    /// Counters for connection events.
+    pub(crate) num_connected: GenericCounter<AtomicI64>,
+    pub(crate) num_disconnected: GenericCounter<AtomicI64>,
+}
+
+impl MetricsByMonitorAndCountry {
+    /// Creates a set of metrics consisting of a few popular countries and the special
+    /// error-condition countries, for the given monitor.
+    pub(crate) fn create_basic_set(
+        monitor_name: &str,
+    ) -> HashMap<String, MetricsByMonitorAndCountry> {
+        let mut metrics_by_country = IntoIterator::into_iter([
+            celes::Country::germany(),
+            celes::Country::the_united_states_of_america(),
+            celes::Country::the_netherlands(),
+        ])
+        .map(|c| {
+            (
+                c.alpha2.to_string(),
+                Self::new_from_iso3166_alpha2(monitor_name, c.alpha2).unwrap(),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+
+        // Add special error-countries.
+        metrics_by_country.insert(
+            COUNTRY_NAME_UNKNOWN.to_string(),
+            Self::new_unknown(monitor_name),
+        );
+        metrics_by_country.insert(
+            COUNTRY_NAME_ERROR.to_string(),
+            Self::new_error(monitor_name),
+        );
+
+        metrics_by_country
+    }
+
+    /// Creates a set of metrics with their `origin_country` set to "Unknown".
+    /// This is used for events for which no origin can be determined.
+    fn new_unknown(monitor_name: &str) -> MetricsByMonitorAndCountry {
+        Self::new_from_country_name(monitor_name, COUNTRY_NAME_UNKNOWN)
+    }
+
+    /// Creates a set of metrics with their `origin_country` set to "Error".
+    /// This is used for events for which determining the origin country failed.
+    fn new_error(monitor_name: &str) -> MetricsByMonitorAndCountry {
+        Self::new_from_country_name(monitor_name, COUNTRY_NAME_ERROR)
+    }
+
+    fn new_from_country_name(monitor_name: &str, country_name: &str) -> MetricsByMonitorAndCountry {
+        MetricsByMonitorAndCountry {
+            num_messages: BITSWAP_MESSAGES_RECEIVED
+                .get_metric_with_label_values(&[monitor_name, country_name])
+                .unwrap(),
+
+            num_entries_cancel: WANTLIST_ENTRIES_RECEIVED
+                .get_metric_with_label_values(&[monitor_name, "cancel", "false", country_name])
+                .unwrap(),
+            num_entries_want_block: WANTLIST_ENTRIES_RECEIVED
+                .get_metric_with_label_values(&[monitor_name, "want_block", "false", country_name])
+                .unwrap(),
+            num_entries_want_block_send_dont_have: WANTLIST_ENTRIES_RECEIVED
+                .get_metric_with_label_values(&[monitor_name, "want_block", "true", country_name])
+                .unwrap(),
+            num_entries_want_have: WANTLIST_ENTRIES_RECEIVED
+                .get_metric_with_label_values(&[monitor_name, "want_have", "false", country_name])
+                .unwrap(),
+            num_entries_want_have_send_dont_have: WANTLIST_ENTRIES_RECEIVED
+                .get_metric_with_label_values(&[monitor_name, "want_have", "true", country_name])
+                .unwrap(),
+
+            num_connected: CONNECTION_EVENTS_CONNECTED
+                .get_metric_with_label_values(&[monitor_name, country_name])
+                .unwrap(),
+            num_disconnected: CONNECTION_EVENTS_DISCONNECTED
+                .get_metric_with_label_values(&[monitor_name, country_name])
+                .unwrap(),
+            num_messages_with_wl_incremental: WANTLIST_MESSAGES_RECEIVED
+                .get_metric_with_label_values(&[monitor_name, "false", country_name])
+                .unwrap(),
+            num_messages_with_wl_full: WANTLIST_MESSAGES_RECEIVED
+                .get_metric_with_label_values(&[monitor_name, "true", country_name])
+                .unwrap(),
+            num_blocks: BITSWAP_BLOCKS_RECEIVED
+                .get_metric_with_label_values(&[monitor_name, country_name])
+                .unwrap(),
+            num_block_presence_have: BITSWAP_BLOCK_PRESENCES_RECEIVED
+                .get_metric_with_label_values(&[monitor_name, "HAVE", country_name])
+                .unwrap(),
+            num_block_presence_dont_have: BITSWAP_BLOCK_PRESENCES_RECEIVED
+                .get_metric_with_label_values(&[monitor_name, "DONT_HAVE", country_name])
+                .unwrap(),
+        }
+    }
+
+    /// Creates a new set of metrics for the country identified by `country_code`.
+    /// If `country_code` is not a valid 2-letter ISO3166-1 code, an error is returned.
+    pub(crate) fn new_from_iso3166_alpha2(
+        monitor_name: &str,
+        country_code: &str,
+    ) -> Result<MetricsByMonitorAndCountry> {
+        let country = celes::Country::from_alpha2(country_code)
+            .map_err(|e| err_msg(format!("{}", e)))
+            .context("invalid country code")?;
+
+        Ok(Self::new_from_country_name(monitor_name, country.long_name))
+    }
 }
 
 pub(crate) fn run_prometheus(addr: SocketAddr) -> Result<()> {

--- a/ipfs-monitoring-plugin-client/src/tcp.rs
+++ b/ipfs-monitoring-plugin-client/src/tcp.rs
@@ -75,6 +75,29 @@ pub struct PushedEvent {
     pub inner: EventType,
 }
 
+impl PushedEvent {
+    /// Creates a constant-width identifier for this event.
+    /// This is potentially expensive.
+    pub fn constant_width_identifier(&self) -> String {
+        // TODO it would be nice if this didn't return a string. I want something that implements Debug, and then formats this on the fly.
+        match &self.inner {
+            EventType::BitswapMessage(msg) => {
+                let mut addrs = msg
+                    .connected_addresses
+                    .iter()
+                    .map(|ma| format!("{}", ma))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                addrs.truncate(30);
+                format!("{:52} [{:30}]", self.peer, addrs)
+            }
+            EventType::ConnectionEvent(conn_event) => {
+                format!("{:52} {:32}", self.peer, format!("{}", conn_event.remote))
+            }
+        }
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub enum EventType {
     #[serde(rename = "bitswap_message")]


### PR DESCRIPTION
This is currently running on the DE2 monitor, producing fancy new graphs.

@lgehr this means that deployments of the monitoring client will need a GeoLite2 Country database.
I think we should use the [geoipupdate](https://dev.maxmind.com/geoip/updating-databases/?lang=en#using-geoip-update) tool, configured via Ansible, and run that once per week, probably on Wednesday. I'll open an issue for that.